### PR TITLE
Bucket Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ artifacts/
 *.ilk
 *.meta
 *.obj
+*.orig
 *.pch
 *.pdb
 *.pgc

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithBucketSeparation.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithBucketSeparation.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using SimpleEventStore.Tests;
+
+namespace SimpleEventStore.AzureDocumentDb.Tests
+{
+    public class AzureDocumentDbEventStoreAppendingWithBucketSeparation : EventStoreAppendingWithBucketSeparation
+    {
+        protected override Task<IStorageEngine> CreateStorageEngine(string bucket)
+        {
+            return StorageEngineFactory.Create("AppendingTestsWithBucket", bucket);
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingWithBucketSeparation.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingWithBucketSeparation.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SimpleEventStore.Tests;
+
+namespace SimpleEventStore.AzureDocumentDb.Tests
+{
+    internal class DatabaseConstants
+    {
+        internal const string DatabaseName = "ReadingTestsWithBucket";
+    }
+
+    public class AzureDocumentDbEventStoreReadingWithBucketSeparation : EventStoreReadingWithBucketSeparation
+    {
+        protected override Task<IStorageEngine> CreateStorageEngine(string bucket)
+        {
+            return StorageEngineFactory.Create(DatabaseConstants.DatabaseName, bucket);
+        }
+
+        protected override async Task AppendDocument(StorageEvent document)
+        {
+            var storageEngine = (AzureDocumentDbStorageEngine) await StorageEngineFactory.Create(DatabaseConstants.DatabaseName);
+            var client = storageEngine.Client;
+
+            var docDbEvent = new DocumentDbStorageEventWithoutBucket
+            {
+                Id = $"{document.StreamId}:{document.EventNumber}",
+                EventId = document.EventId,
+                Body = JObject.FromObject(document.EventBody),
+                BodyType = storageEngine.TypeMap.GetNameFromType(document.EventBody.GetType()),
+                StreamId = document.StreamId,
+                EventNumber = document.EventNumber
+            };
+
+            await client.CreateDocumentAsync(storageEngine.CommitsLink, docDbEvent);
+        }
+
+        private class DocumentDbStorageEventWithoutBucket
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("eventId")]
+            public Guid EventId { get; set; }
+
+            [JsonProperty("body")]
+            public JObject Body { get; set; }
+
+            [JsonProperty("bodyType")]
+            public string BodyType { get; set; }
+
+            [JsonProperty("streamId")]
+            public string StreamId { get; set; }
+
+            [JsonProperty("eventNumber")]
+            public int EventNumber { get; set; }
+
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
@@ -11,7 +11,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
 {
     internal static class StorageEngineFactory
     {
-        internal static async Task<IStorageEngine> Create(string databaseName)
+        internal static async Task<IStorageEngine> Create(string databaseName, string bucket = AzureDocumentDbStorageEngine.DefaultBucket)
         {
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
@@ -35,6 +35,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
                 {
                     o.ConsistencyLevel = consistencyLevelEnum;
                     o.CollectionRequestUnits = 400;
+                    o.Bucket = bucket;
                 })
                 .UseTypeMap(new ConfigurableSerializationTypeMap()
                     .RegisterTypes(

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
@@ -9,6 +9,7 @@ namespace SimpleEventStore.AzureDocumentDb
             this.ConsistencyLevel = ConsistencyLevel.Session;
             this.CollectionRequestUnits = 400;
             this.CollectionName = "Commits";
+            this.Bucket = AzureDocumentDbStorageEngine.DefaultBucket;
         }
 
         public string CollectionName { get; set; }
@@ -16,5 +17,7 @@ namespace SimpleEventStore.AzureDocumentDb
         public ConsistencyLevel ConsistencyLevel { get; set; }
 
         public int CollectionRequestUnits { get; set; }
+
+        public string Bucket { get; set; }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
@@ -4,10 +4,11 @@ function appendToStream(documents) {
     var collectionLink = collection.getSelfLink();
     var streamId = documents[0].streamId;
     var expectedEventNumber = documents[0].eventNumber - 1;
+    var bucket = documents[0].bucket;
 
     var concurrencyQuery = {
-        query: "SELECT TOP 1 c.eventNumber FROM Commits c WHERE c.streamId = @streamId ORDER BY c.eventNumber DESC",
-        parameters: [{ name: "@streamId", value: streamId }]
+        query: "SELECT TOP 1 c.eventNumber FROM Commits c WHERE c.streamId = @streamId AND (c.bucket ?? 'default') = @bucket ORDER BY c.eventNumber DESC",
+        parameters: [{ name: "@streamId", value: streamId }, { name: "@bucket", value: bucket }]
     };
 
     var accepted = collection.queryDocuments(collectionLink, concurrencyQuery, {}, onConcurrencyQueryCompleted);

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreAppendingWithBucketSeparation.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreAppendingWithBucketSeparation.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SimpleEventStore.Tests.Events;
+using Xunit;
+
+namespace SimpleEventStore.Tests
+{
+    public abstract class EventStoreAppendingWithBucketSeparation : EventStoreWithBucketBase
+    {
+        [Fact]
+        public async Task when_appending_to_an_existing_stream_identifier_but_in_a_different_bucket_the_event_is_saved_to_the_correct_bucket()
+        {
+            var streamId = Guid.NewGuid().ToString();
+
+            var ordersEventStore = await GetOrdersEventStore();
+            var orderEvent = new EventData(Guid.NewGuid(), new OrderCreated(OrdersBucket));
+            await ordersEventStore.AppendToStream(streamId, 0, orderEvent);
+
+            var paymentsEventStore = await GetPaymentsEventStore();
+            var paymentEvent = new EventData(orderEvent.EventId, new PaymentTaken(new Random().Next(1, 100000)));
+            await paymentsEventStore.AppendToStream(streamId, 0, paymentEvent);
+
+            var events = await ordersEventStore.ReadStreamForwards(streamId);
+            Assert.Equal(1, events.Count);
+            Assert.Equal(OrdersBucket, events.Select(e => (OrderCreated)e.EventBody).First().OrderId);
+
+            events = await paymentsEventStore.ReadStreamForwards(streamId);
+            Assert.Equal(1, events.Count);
+            Assert.Equal(((PaymentTaken)paymentEvent.Body).Amount, events.Select(e => (PaymentTaken)e.EventBody).First().Amount);
+        }
+
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReadingWithBucketSeparation.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReadingWithBucketSeparation.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SimpleEventStore.Tests.Events;
+using Xunit;
+
+namespace SimpleEventStore.Tests
+{
+    public abstract class EventStoreReadingWithBucketSeparation : EventStoreWithBucketBase
+    {
+        protected abstract Task AppendDocument(StorageEvent document);
+
+        [Fact]
+        public async Task existing_events_stored_without_a_bucket_are_included_when_a_bucket_is_not_specified_for_retreival()
+        {
+            var streamId = Guid.NewGuid().ToString();
+            await AppendDocument(new StorageEvent(streamId, new EventData(Guid.NewGuid(), new OrderCreated(streamId)), 1));
+
+            var subject = await GetEventStoreWithNoBucketSpecified();
+
+            await subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
+
+            var events = await subject.ReadStreamForwards(streamId);
+
+            Assert.Equal(2, events.Count);
+            Assert.IsType<OrderCreated>(events.First().EventBody);
+            Assert.IsType<OrderDispatched>(events.Skip(1).Single().EventBody);
+        }
+
+        [Fact]
+        public async Task events_stored_without_a_bucket_but_with_different_streams_are_kept_isolated()
+        {
+            var firstStream = Guid.NewGuid().ToString();
+            await AppendDocument(new StorageEvent(firstStream, new EventData(Guid.NewGuid(), new OrderCreated(firstStream)), 1));
+
+            var secondStream = Guid.NewGuid().ToString();
+            await AppendDocument(new StorageEvent(secondStream, new EventData(Guid.NewGuid(), new OrderCreated(secondStream)), 1));
+
+            var subject = await GetEventStoreWithNoBucketSpecified();
+
+            Assert.Equal(1, (await subject.ReadStreamForwards(firstStream)).Count);
+            Assert.Equal(1, (await subject.ReadStreamForwards(secondStream)).Count);
+        }
+
+        [Fact]
+        public async Task when_reading_a_stream_only_the_required_events_are_returned()
+        {
+            var streamId = Guid.NewGuid().ToString();
+            var subject = await GetEventStoreWithNoBucketSpecified();
+
+            await AppendDocument(new StorageEvent(streamId, new EventData(Guid.NewGuid(), new OrderCreated(streamId)), 1));
+            await AppendDocument(new StorageEvent(streamId, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)), 2));
+
+            var events = await subject.ReadStreamForwards(streamId, startPosition: 2, numberOfEventsToRead: 1);
+
+            Assert.Equal(1, events.Count);
+            Assert.IsType<OrderDispatched>(events.First().EventBody);
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreWithBucketBase.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreWithBucketBase.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+
+namespace SimpleEventStore.Tests
+{
+    public abstract class EventStoreWithBucketBase
+    {
+        protected const string DefaultBucket = "default";
+        protected const string OrdersBucket = "Orders";
+        protected const string PaymentsBucket = "Payments";
+
+        protected async Task<EventStore> GetEventStoreWithNoBucketSpecified()
+        {
+            var storageEngine = await CreateStorageEngine(DefaultBucket);
+            return new EventStore(storageEngine);
+        }
+
+        protected async Task<EventStore> GetOrdersEventStore()
+        {
+            var storageEngine = await CreateStorageEngine(OrdersBucket);
+            return new EventStore(storageEngine);
+        }
+
+        protected async Task<EventStore> GetPaymentsEventStore()
+        {
+            var storageEngine = await CreateStorageEngine(PaymentsBucket);
+            return new EventStore(storageEngine);
+        }
+
+        protected abstract Task<IStorageEngine> CreateStorageEngine(string bucket);
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.Tests/Events/PaymentTaken.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/Events/PaymentTaken.cs
@@ -1,0 +1,12 @@
+namespace SimpleEventStore.Tests.Events
+{
+    public class PaymentTaken
+    {
+        public decimal Amount { get; }
+
+        public PaymentTaken(decimal amount)
+        {
+            Amount = amount;
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.Tests/InMemory/InMemoryEventStoreAppendingWithBucketSeparation.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/InMemory/InMemoryEventStoreAppendingWithBucketSeparation.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using SimpleEventStore.InMemory;
+
+namespace SimpleEventStore.Tests.InMemory
+{
+    public class InMemoryEventStoreAppendingWithBucketSeparation : EventStoreAppendingWithBucketSeparation
+    {
+        protected override Task<IStorageEngine> CreateStorageEngine(string bucket)
+        {
+            return Task.FromResult((IStorageEngine)new InMemoryStorageEngine());
+        }
+    }
+}


### PR DESCRIPTION
**What problem does this PR solve?**
This PR allows multiple event stores to exist within a single CosmosDB collection. It achieves this by adding a Bucket property on the DocumentDbStorageEvent class to identity which event store the event belongs to.

**Why would you want to store multiple event stores in a single CosmosDB collection?**
CosmosDB charges per collection, so for test or low volume environments it can become prohibitively expensive to support multiple event stores. Under those circumstances it is advantageous to have a single collection reused multiple times.

**How do I specify which bucket I would like to use?**
```C#            
var builder = new AzureDocumentDbStorageEngineBuilder(client, "mydb");
var engine = builder.UseCollection(
    options => {
        options.Bucket = "widgets";
    }
).Build();
```

**Design Decisions / Tech Debt**
1. I made the decision not to update any events that existed before the Bucket property was added and have instead tried to be defensive with the selection of existing events where the Bucket property is not available. 
If the Bucket property is not set then it's assumed to be 'default' and I've added unit tests to test this scenario. 
Not updating existing events does introduce complexity within the library which could be mitigated with a script such as this:

    `PSEUDO Code: update commits where isnull(bucket) set bucket = 'default'`

    However, making someone run an update script in order to use the library brings its own issues, so I avoided it.

2. The identifier of the event now includes the name of the bucket as well as the event number. Any existing queries that directly access the documents within the event store and rely on the identifier will require updating.

    Old format: StreamId:EventNumber
    New format: StreamId:Bucket:EventNumber