### PR TITLE
Fix KeyNotFoundException when reading an empty stream

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
@@ -13,6 +13,17 @@ namespace SimpleEventStore.Tests
     public abstract class EventStoreReading : EventStoreTestBase
     {
         [Fact]
+        public async Task when_reading_a_stream_which_has_no_events_an_empty_list_is_returned()
+        {
+            var streamId = Guid.NewGuid().ToString();
+            var subject = await GetEventStore();
+
+            var events = await subject.ReadStreamForwards(streamId);
+
+            Assert.Equal(0, events.Count());
+        }
+
+        [Fact]
         public async Task when_reading_a_stream_all_events_are_returned()
         {
             var streamId = Guid.NewGuid().ToString();

--- a/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
@@ -43,7 +43,16 @@ namespace SimpleEventStore.InMemory
 
         public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead)
         {
-            IReadOnlyCollection<StorageEvent> result = streams[streamId].Skip(startPosition - 1).Take(numberOfEventsToRead).ToList().AsReadOnly();
+            IReadOnlyCollection<StorageEvent> result;
+            if (!streams.ContainsKey(streamId))
+            {
+                result = new List<StorageEvent>(0).AsReadOnly();
+            }
+            else
+            {
+                result = streams[streamId].Skip(startPosition - 1).Take(numberOfEventsToRead).ToList().AsReadOnly();
+            }
+             
             return Task.FromResult(result);
         }
 


### PR DESCRIPTION
Fix KeyNotFoundException when reading an empty stream using the InMemoryStorageEngine