### PR TITLE
Added capability for consumers to create unit tests for TTL scenarios

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.Tests/InMemory/InMemoryStorageEngineAppending.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/InMemory/InMemoryStorageEngineAppending.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using SimpleEventStore.InMemory;
+using SimpleEventStore.Tests.Events;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SimpleEventStore.Tests.InMemory
+{
+    [TestFixture]
+    public class InMemoryStorageEngineAppending
+    {
+        private string _streamId;
+        private InMemoryStorageEngine _engine;
+        private StorageEvent _secondEvent;
+
+        [SetUp]
+        public void Setup()
+        {
+            _streamId = Guid.NewGuid().ToString();
+            _engine = new InMemoryStorageEngine();
+            _secondEvent = new StorageEvent(
+                _streamId,
+                new EventData(
+                    Guid.NewGuid(),
+                    new OrderCreated(_streamId)),
+                2);
+        }
+
+        [Test]
+        public void when_appending_to_stream_and_conflict_check_is_disabled_then_tolerate_events_missing_from_storage_to_permit_setup_of_ttl_unit_test_scenarios()
+        {
+            Assert.DoesNotThrowAsync(() =>
+                _engine.AppendToStream(
+                    _streamId,
+                    new[] { _secondEvent },
+                    ConcurrencyCheck.AllowMissingAndDuplicatedEventNumbersAndAppendRegardless));
+        }
+
+        [Test]
+        public async Task when_appending_to_stream_and_conflict_check_is_disabled_conflicting_events_are_stored_and_can_be_retrieved()
+        {
+            await _engine.AppendToStream(
+                _streamId,
+                new[] { _secondEvent },
+                ConcurrencyCheck.AllowMissingAndDuplicatedEventNumbersAndAppendRegardless);
+
+            var actualStreamContent = await _engine.ReadStreamForwards(_streamId, 0, 2);
+            Assert.AreEqual(1, actualStreamContent.Count());
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore/InMemory/ConcurrencyCheck.cs
+++ b/src/SimpleEventStore/SimpleEventStore/InMemory/ConcurrencyCheck.cs
@@ -1,0 +1,8 @@
+﻿namespace SimpleEventStore.InMemory
+{
+    public enum ConcurrencyCheck
+    {
+        ThrowExceptionOnConflict,
+        AllowMissingAndDuplicatedEventNumbersAndAppendRegardless
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
@@ -13,6 +13,9 @@ namespace SimpleEventStore.InMemory
         private readonly List<StorageEvent> allEvents = new List<StorageEvent>();
 
         public Task AppendToStream(string streamId, IEnumerable<StorageEvent> events)
+            => AppendToStream(streamId, events, ConcurrencyCheck.ThrowExceptionOnConflict);
+
+        public Task AppendToStream(string streamId, IEnumerable<StorageEvent> events, ConcurrencyCheck concurrencyCheck)
         {
             return Task.Run(() =>
             {
@@ -23,7 +26,8 @@ namespace SimpleEventStore.InMemory
 
                 var firstEvent = events.First();
 
-                if (firstEvent.EventNumber - 1 != streams[streamId].Count)
+                if (concurrencyCheck != ConcurrencyCheck.AllowMissingAndDuplicatedEventNumbersAndAppendRegardless
+                    && firstEvent.EventNumber - 1 != streams[streamId].Count)
                 {
                     throw new ConcurrencyException($"Concurrency conflict when appending to stream {streamId}. Expected revision {firstEvent.EventNumber} : Actual revision {streams[streamId].Count}");
                 }


### PR DESCRIPTION
Added capability for consumers to create unit tests for TTL scenarios.

To achieve that goal, this PR adds support in the InMemoryStorageEngine for setting up an event stream where a per-event TTL concept may have mutated the stream in an underlying storage engine.

Once a "corrupted" (mutated) stream has been set up in storage then further calls to append events normally will always cause the concurrency check to fail due to the check relying on the count of events in the stream rather than the event number of the last event in the stream.  This has deliberately not been altered in this PR as the only identified use case is to set up a stream with missing initial events to allow consuming code to be testable when an incomplete stream is returned from the store.  For safety, attempting to write back to that mutated stream fails by design.