### PR TITLE
Added JsonSerializerSettings / JsonSerializer support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ return await new AzureDocumentDbStorageEngineBuilder(client, databaseName)
 			typeof(OrderCreated).GetTypeInfo().Assembly,
 			t => t.Namespace.EndsWith("Events"),
 			t => t.Name))
+	.UseJsonSerializerSettings(settings)
 	.Build()
 	.Initialise();
 ```
@@ -82,6 +83,11 @@ Allows you to control the event body/metadata type names.  Built in implementati
 - ConfigurableSerializationTypeMap - provides full control.
 
 While the default implementation is simple, this isn't great for versioning as contract assembly version number changes will render events unreadable.  Therefore the configurable implementation or your own implementation is recommended.
+
+### UseJsonSerializerSettings
+Allows you to customise JSON serialization of the event body and metadata.  If you do not call this method a default JsonSerializerSettings instance is used.
+
+For consistent serialization provide the same serialzer settings to your DocumentClient.
 
 ### Initialise
 Calling the operation creates the underlying collection based on the DatabaseOptions.  This ensures the required stored procedure is present too.  It is safe to call this multiple times.

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -45,7 +45,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(collection.PartitionKey.Paths.Single(), Is.EqualTo("/streamId"));
             Assert.That(collection.IndexingPolicy.IncludedPaths.Count, Is.EqualTo(1));
             Assert.That(collection.IndexingPolicy.IncludedPaths[0].Path, Is.EqualTo("/*"));
-            Assert.That(collection.IndexingPolicy.ExcludedPaths.Count, Is.EqualTo(2));
+            Assert.That(collection.IndexingPolicy.ExcludedPaths.Count, Is.EqualTo(3));
             Assert.That(collection.IndexingPolicy.ExcludedPaths[0].Path, Is.EqualTo("/body/*"));
             Assert.That(collection.IndexingPolicy.ExcludedPaths[1].Path, Is.EqualTo("/metadata/*"));
         }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NUnit.Framework;
+using SimpleEventStore.Tests;
+using SimpleEventStore.Tests.Events;
+
+namespace SimpleEventStore.AzureDocumentDb.Tests
+{
+    [TestFixture]
+    public class AzureDocumentDbEventStoreAppendingWithConverters : EventStoreTestBase
+    {
+        [Test]
+        public async Task when_appending_an_event_that_requires_a_converter_the_event_is_saved_and_read()
+        {
+            var streamId = Guid.NewGuid().ToString();
+            var subject = await GetEventStore();
+            var @event = new EventData(Guid.NewGuid(), new OrderProcessed(streamId, new Version(1, 2, 0)));
+            
+            await subject.AppendToStream(streamId, 0, @event);
+
+            var stream = await subject.ReadStreamForwards(streamId);
+            Assert.That(stream.Count, Is.EqualTo(1));
+            Assert.That(stream.Single().StreamId, Is.EqualTo(streamId));
+            Assert.That(stream.Single().EventId, Is.EqualTo(@event.EventId));
+            Assert.That(stream.Single().EventNumber, Is.EqualTo(1));
+        }
+
+        protected override Task<IStorageEngine> CreateStorageEngine()
+        {
+            return StorageEngineFactory.Create("JsonSerializationSettingsTests",
+                new JsonSerializerSettings
+                {
+                    Converters = new List<JsonConverter>
+                    {
+                        new VersionConverter()
+                    }
+                });
+        }
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbStorageEngineBuilderTests.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbStorageEngineBuilderTests.cs
@@ -47,6 +47,13 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.Throws<ArgumentNullException>(() => builder.UseTypeMap(null));
         }
 
+        [Test]
+        public void when_setting_the_jsonserializationsettings_it_must_be_supplied()
+        {
+            var builder = new AzureDocumentDbStorageEngineBuilder(CreateClient(), "Test");
+            Assert.Throws<ArgumentNullException>(() => builder.UseJsonSerializerSettings(null));
+        }
+
         private static DocumentClient CreateClient()
         {
             var client = new DocumentClient(new Uri("https://localhost:8081/"), "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/DocumentClientFactory.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/DocumentClientFactory.cs
@@ -1,12 +1,18 @@
 using System;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
 {
     internal static class DocumentClientFactory
     {
         internal static DocumentClient Create(string databaseName)
+        {
+            return Create(databaseName, new JsonSerializerSettings());
+        }
+
+        internal static DocumentClient Create(string databaseName, JsonSerializerSettings settings)
         {
             var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
@@ -15,7 +21,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             var documentDbUri = config["Uri"];
             var authKey = config["AuthKey"];
 
-            return new DocumentClient(new Uri(documentDbUri), authKey);
+            return new DocumentClient(new Uri(documentDbUri), authKey, settings);
         }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/DocumentDbStorageEventTests.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/DocumentDbStorageEventTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SimpleEventStore.Tests.Events;
 using NUnit.Framework;
@@ -29,7 +30,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
                 typeof(OrderCreated).GetTypeInfo().Assembly,
                 t => t.Namespace != null && t.Namespace.EndsWith("Events"),
                 t => t.Name);
-            var result = sut.ToStorageEvent(typeMap);
+            var result = sut.ToStorageEvent(typeMap, JsonSerializer.CreateDefault());
 
             Assert.That(result.StreamId, Is.EqualTo(sut.StreamId));
             Assert.That(((OrderCreated)result.EventBody).OrderId, Is.EqualTo(body.OrderId));

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -23,7 +23,7 @@ namespace SimpleEventStore.AzureDocumentDb
         private readonly ISerializationTypeMap typeMap;
         private readonly JsonSerializer jsonSerializer;
 
-        internal AzureDocumentDbStorageEngine(DocumentClient client, string databaseName, CollectionOptions collectionOptions, LoggingOptions loggingOptions, ISerializationTypeMap typeMap, JsonSerializerSettings settings)
+        internal AzureDocumentDbStorageEngine(DocumentClient client, string databaseName, CollectionOptions collectionOptions, LoggingOptions loggingOptions, ISerializationTypeMap typeMap, JsonSerializer serializer)
         {
             this.client = client;
             this.databaseName = databaseName;
@@ -32,7 +32,7 @@ namespace SimpleEventStore.AzureDocumentDb
             this.storedProcLink = UriFactory.CreateStoredProcedureUri(databaseName, collectionOptions.CollectionName, AppendStoredProcedureName);
             this.loggingOptions = loggingOptions;
             this.typeMap = typeMap;
-            this.jsonSerializer = JsonSerializer.Create(settings);
+            this.jsonSerializer = serializer;
         }
 
         public async Task<IStorageEngine> Initialise()

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
@@ -55,7 +55,7 @@ namespace SimpleEventStore.AzureDocumentDb
 
         public IStorageEngine Build()
         {
-            var engine = new AzureDocumentDbStorageEngine(this.client, this.databaseName, this.collectionOptions, this.loggingOptions, this.typeMap, this.jsonSerializerSettings);
+            var engine = new AzureDocumentDbStorageEngine(this.client, this.databaseName, this.collectionOptions, this.loggingOptions, this.typeMap, JsonSerializer.Create(this.jsonSerializerSettings));
             return engine;
         }
     }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Azure.Documents.Client;
+using Newtonsoft.Json;
 
 namespace SimpleEventStore.AzureDocumentDb
 {
@@ -10,6 +11,7 @@ namespace SimpleEventStore.AzureDocumentDb
         private readonly CollectionOptions collectionOptions = new CollectionOptions();
         private readonly LoggingOptions loggingOptions = new LoggingOptions();
         private ISerializationTypeMap typeMap = new DefaultSerializationTypeMap();
+        private JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
 
         public AzureDocumentDbStorageEngineBuilder(DocumentClient client, string databaseName)
         {
@@ -44,9 +46,16 @@ namespace SimpleEventStore.AzureDocumentDb
             return this;
         }
 
+        public AzureDocumentDbStorageEngineBuilder UseJsonSerializerSettings(JsonSerializerSettings settings)
+        {
+            Guard.IsNotNull(nameof(settings), settings);
+            this.jsonSerializerSettings = settings;
+            return this;
+        }
+
         public IStorageEngine Build()
         {
-            var engine = new AzureDocumentDbStorageEngine(this.client, this.databaseName, this.collectionOptions, this.loggingOptions, this.typeMap);
+            var engine = new AzureDocumentDbStorageEngine(this.client, this.databaseName, this.collectionOptions, this.loggingOptions, this.typeMap, this.jsonSerializerSettings);
             return engine;
         }
     }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
@@ -33,16 +33,16 @@ namespace SimpleEventStore.AzureDocumentDb
         [JsonProperty("eventNumber")]
         public int EventNumber { get; set; }
 
-        public static DocumentDbStorageEvent FromStorageEvent(StorageEvent @event, ISerializationTypeMap typeMap)
+        public static DocumentDbStorageEvent FromStorageEvent(StorageEvent @event, ISerializationTypeMap typeMap, JsonSerializer serializer)
         {
             var docDbEvent = new DocumentDbStorageEvent();
             docDbEvent.Id = $"{@event.StreamId}:{@event.EventNumber}";
             docDbEvent.EventId = @event.EventId;
-            docDbEvent.Body = JObject.FromObject(@event.EventBody);
+            docDbEvent.Body = JObject.FromObject(@event.EventBody, serializer);
             docDbEvent.BodyType = typeMap.GetNameFromType(@event.EventBody.GetType());
             if (@event.Metadata != null)
             {
-                docDbEvent.Metadata = JObject.FromObject(@event.Metadata);
+                docDbEvent.Metadata = JObject.FromObject(@event.Metadata, serializer);
                 docDbEvent.MetadataType = typeMap.GetNameFromType(@event.Metadata.GetType());
             }
             docDbEvent.StreamId = @event.StreamId;
@@ -68,10 +68,10 @@ namespace SimpleEventStore.AzureDocumentDb
             return docDbEvent;
         }
 
-        public StorageEvent ToStorageEvent(ISerializationTypeMap typeMap)
+        public StorageEvent ToStorageEvent(ISerializationTypeMap typeMap, JsonSerializer serializer)
         {
-            object body = Body.ToObject(typeMap.GetTypeFromName(BodyType));
-            object metadata = Metadata?.ToObject(typeMap.GetTypeFromName(MetadataType));
+            object body = Body.ToObject(typeMap.GetTypeFromName(BodyType), serializer);
+            object metadata = Metadata?.ToObject(typeMap.GetTypeFromName(MetadataType), serializer);
             return new StorageEvent(StreamId, new EventData(EventId, body, metadata), EventNumber);
         }
     }

--- a/src/SimpleEventStore/SimpleEventStore.Tests/Events/OrderProcessed.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/Events/OrderProcessed.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace SimpleEventStore.Tests.Events
+{
+    public class OrderProcessed
+    {
+        public string OrderId { get; private set; }
+
+        public Version OrderProcessorVersion { get; set; }
+
+        public OrderProcessed(string orderId, Version orderProcessorVersion)
+        {
+            OrderId = orderId;
+            OrderProcessorVersion = orderProcessorVersion;
+        }
+    }
+}


### PR DESCRIPTION
Any methods that use `JObject.FromObject` or `JObject.ToObject` can now use a `JsonSerializer` which is constructed from a `JsonSerializationSettings` instance, allowing custom serialization rules to be applied transparently without the event store being aware.

The `JsonSerializationSettings` instance is injected from the `AzureDocumentDbStorageEngineBuilder`. This allows custom serialization converters (and other Json.Net extensions) to be provided to the `AzureDocumentDbStorageEngine` and allows control over how the events are serialized.

I tried to avoid this change by providing the `JsonSerializationSettings` instance to the `DocumentClient`, but the use of `JObject.FromObject` and `JObject.ToObject` used their own `JsonSerializationSettings` which ignored the converters.

An alternative to this PR is to change the type of the `DocumentDbStorageEvent.Body` property to object instead of JObject which would force the DocumentClient to perform the body serialization, however, this may break existing stores due to the contract change.

Some use cases for this level of event serialization

- Serialization of types which don't serialize without converters (System.Version is one example of this)
- Field level encryption of events (using an approach like this: https://github.com/stevewgh/SecretSerializer)
- Class level compression by using a similar approach used with field level encyption #25 