### PR TITLE
Match case when retrieving appendToStream.js via Resources

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -126,7 +126,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 await client.CreateStoredProcedureAsync(commitsLink, new StoredProcedure
                 {
                     Id = AppendStoredProcedureName,
-                    Body = Resources.GetString("AppendToStream.js")
+                    Body = Resources.GetString("appendToStream.js")
                 });
             }
         }


### PR DESCRIPTION
It took a while to get back around to this - only just got around to spinning up a real CosmosDB instance. The resource name needs to match filename's case too - tests against a real CosmosDB instance will fail without this.

Hope this didn't cause any headaches - although I suppose not on case-insensitive file systems. Do you make use of this project in production at ASOS?

Now it builds and, crucially, all the tests pass on Ubuntu :rocket: :penguin:

 (This is only true for the netcoreapp2.0 tests - the net452 tests via mono will fail at runtime due to [issue #7410](https://github.com/mono/mono/issues/7410) since `DefaultTrace` from `Microsoft.Azure.DocumentDb` is hard-coupled with `EventProviderTraceListener`.)