### PR TITLE
Update to latest CosmosDB package version

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
@@ -9,14 +9,14 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.6.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.18.0" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0.0" Condition="'$(TargetFramework)' == 'net452'" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
@@ -5,8 +5,8 @@
     <BuildVersion>1.0.0</BuildVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.6.0" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.18.0" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
@@ -7,9 +7,9 @@
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <PropertyGroup>
     <Title>SimpleEventStore.Tests</Title>


### PR DESCRIPTION
N.B.: Very old installations of the local CosmosDB emulator will need to be upgraded on development machines before tests execute.  To do this, either update to the latest Docker image, or (if using the MSI package), uninstall the current version first (important!) and then install the latest emulator version from https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator.