### PR TITLE
Allow Initialise with shared throughput

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Building Simple Event Store
+Clone repository
+```sh
+git clone git@github.com:ASOS/SimpleEventStore.git
+```
+
+Enter the repository and build the provider and run the tests using cake
+```sh
+cd build
+./build.ps1
+```

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -45,7 +45,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(collection.PartitionKey.Paths.Single(), Is.EqualTo("/streamId"));
             Assert.That(collection.IndexingPolicy.IncludedPaths.Count, Is.EqualTo(1));
             Assert.That(collection.IndexingPolicy.IncludedPaths[0].Path, Is.EqualTo("/*"));
-            Assert.That(collection.IndexingPolicy.ExcludedPaths.Count, Is.EqualTo(2));
+            Assert.That(collection.IndexingPolicy.ExcludedPaths.Count, Is.EqualTo(3));
             Assert.That(collection.IndexingPolicy.ExcludedPaths[0].Path, Is.EqualTo("/body/*"));
             Assert.That(collection.IndexingPolicy.ExcludedPaths[1].Path, Is.EqualTo("/metadata/*"));
         }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -1,22 +1,24 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
 using NUnit.Framework;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
 {
     [TestFixture]
-    public class AzureDocumentDbEventStoreInitializing
+    public class AzureDocumentDBEventStoreInitializing
     {
         private const string DatabaseName = "InitializeTests";
 
         [OneTimeTearDown]
-        public Task TearDownDatabase()
+        public async Task TearDownDatabase()
         {
             var client = DocumentClientFactory.Create(DatabaseName);
-            return client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseName));
+            await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseName));
         }
 
         [Test]

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -1,24 +1,22 @@
 using System;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
 using NUnit.Framework;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
 {
     [TestFixture]
-    public class AzureDocumentDBEventStoreInitializing
+    public class AzureDocumentDbEventStoreInitializing
     {
         private const string DatabaseName = "InitializeTests";
 
         [OneTimeTearDown]
-        public async Task TearDownDatabase()
+        public Task TearDownDatabase()
         {
             var client = DocumentClientFactory.Create(DatabaseName);
-            await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseName));
+            return client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseName));
         }
 
         [Test]

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
@@ -21,10 +21,10 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             await sut.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated("TEST-ORDER")));
 
             Assert.NotNull(response);
-            TestContext.Out.WriteLine($"Charge: {response.RequestCharge}");
-            TestContext.Out.WriteLine($"Quota Usage: {response.CurrentResourceQuotaUsage}");
-            TestContext.Out.WriteLine($"Max Resource Quote: {response.MaxResourceQuota}");
-            TestContext.Out.WriteLine($"Response headers: {response.ResponseHeaders}");
+            await TestContext.Out.WriteLineAsync($"Charge: {response.RequestCharge}");
+            await TestContext.Out.WriteLineAsync($"Quota Usage: {response.CurrentResourceQuotaUsage}");
+            await TestContext.Out.WriteLineAsync($"Max Resource Quote: {response.MaxResourceQuota}");
+            await TestContext.Out.WriteLineAsync($"Response headers: {response.ResponseHeaders}");
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(logCount, Is.EqualTo(2));
         }
 
-        private static async Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string databaseName = "LoggingTests")
+        private static Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string databaseName = "LoggingTests")
         {
             var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
@@ -57,7 +57,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
 
             DocumentClient client = new DocumentClient(new Uri(documentDbUri), authKey);
 
-            return await new AzureDocumentDbStorageEngineBuilder(client, databaseName)
+            return new AzureDocumentDbStorageEngineBuilder(client, databaseName)
                 .UseCollection(o =>
                 {
                     o.ConsistencyLevel = consistencyLevelEnum;

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
@@ -21,10 +21,10 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             await sut.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated("TEST-ORDER")));
 
             Assert.NotNull(response);
-            await TestContext.Out.WriteLineAsync($"Charge: {response.RequestCharge}");
-            await TestContext.Out.WriteLineAsync($"Quota Usage: {response.CurrentResourceQuotaUsage}");
-            await TestContext.Out.WriteLineAsync($"Max Resource Quote: {response.MaxResourceQuota}");
-            await TestContext.Out.WriteLineAsync($"Response headers: {response.ResponseHeaders}");
+            TestContext.Out.WriteLine($"Charge: {response.RequestCharge}");
+            TestContext.Out.WriteLine($"Quota Usage: {response.CurrentResourceQuotaUsage}");
+            TestContext.Out.WriteLine($"Max Resource Quote: {response.MaxResourceQuota}");
+            TestContext.Out.WriteLine($"Response headers: {response.ResponseHeaders}");
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(logCount, Is.EqualTo(2));
         }
 
-        private static Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string databaseName = "LoggingTests")
+        private static async Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string databaseName = "LoggingTests")
         {
             var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
@@ -57,7 +57,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
 
             DocumentClient client = new DocumentClient(new Uri(documentDbUri), authKey);
 
-            return new AzureDocumentDbStorageEngineBuilder(client, databaseName)
+            return await new AzureDocumentDbStorageEngineBuilder(client, databaseName)
                 .UseCollection(o =>
                 {
                     o.ConsistencyLevel = consistencyLevelEnum;

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
@@ -31,9 +31,9 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(stream.First().EventNumber, Is.EqualTo(2));
         }
 
-        private static async Task SimulateTimeToLiveExpiration(string databaseName, string collectionName, DocumentClient client, string streamId)
+        private static Task SimulateTimeToLiveExpiration(string databaseName, string collectionName, DocumentClient client, string streamId)
         {
-            await client.DeleteDocumentAsync(
+            return client.DeleteDocumentAsync(
                 UriFactory.CreateDocumentUri(databaseName, collectionName, $"{streamId}:1"),
                 new RequestOptions() { PartitionKey = new PartitionKey(streamId) });
         }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
@@ -31,9 +31,9 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(stream.First().EventNumber, Is.EqualTo(2));
         }
 
-        private static Task SimulateTimeToLiveExpiration(string databaseName, string collectionName, DocumentClient client, string streamId)
+        private static async Task SimulateTimeToLiveExpiration(string databaseName, string collectionName, DocumentClient client, string streamId)
         {
-            return client.DeleteDocumentAsync(
+            await client.DeleteDocumentAsync(
                 UriFactory.CreateDocumentUri(databaseName, collectionName, $"{streamId}:1"),
                 new RequestOptions() { PartitionKey = new PartitionKey(streamId) });
         }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
@@ -10,7 +10,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0.0" Condition="'$(TargetFramework)' == 'net452'" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
@@ -9,7 +9,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" Condition="'$(TargetFramework)' == 'net452'" />
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0.0" Condition="'$(TargetFramework)' == 'net452'" />

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -93,18 +93,21 @@ namespace SimpleEventStore.AzureDocumentDb
             return events.AsReadOnly();
         }
 
-        private async Task CreateDatabaseIfItDoesNotExist()
+        private Task CreateDatabaseIfItDoesNotExist()
         {
-            await client.CreateDatabaseIfNotExistsAsync(new Database { Id = databaseName });
+            return client.CreateDatabaseIfNotExistsAsync(new Database { Id = databaseName });
         }
 
-        private async Task CreateCollectionIfItDoesNotExist()
+        private Task CreateCollectionIfItDoesNotExist()
         {
             var databaseUri = UriFactory.CreateDatabaseUri(databaseName);
 
-            var collection = new DocumentCollection();
-            collection.Id = collectionOptions.CollectionName;
-            collection.DefaultTimeToLive = collectionOptions.DefaultTimeToLive;
+            var collection = new DocumentCollection
+            {
+                Id = collectionOptions.CollectionName,
+                DefaultTimeToLive = collectionOptions.DefaultTimeToLive
+            };
+
             collection.PartitionKey.Paths.Add("/streamId");
             collection.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
             collection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/body/*" });
@@ -115,7 +118,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 OfferThroughput = collectionOptions.CollectionRequestUnits
             };
 
-            await client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
+            return client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
         }
 
         private async Task CreateAppendStoredProcedureIfItDoesNotExist()

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -100,7 +100,7 @@ namespace SimpleEventStore.AzureDocumentDb
             return events.AsReadOnly();
         }
 
-        private async Task CreateDatabaseIfItDoesNotExist()
+        private Task CreateDatabaseIfItDoesNotExist()
         {
             return client.CreateDatabaseIfNotExistsAsync(
                 new Database { Id = databaseName },
@@ -110,7 +110,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 });
         }
 
-        private async Task CreateCollectionIfItDoesNotExist()
+        private Task CreateCollectionIfItDoesNotExist()
         {
             var collection = new DocumentCollection
             {
@@ -128,7 +128,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 OfferThroughput = collectionOptions.CollectionRequestUnits
             };
 
-            await client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
+            return client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
         }
 
         private async Task CreateAppendStoredProcedureIfItDoesNotExist()

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -93,21 +93,18 @@ namespace SimpleEventStore.AzureDocumentDb
             return events.AsReadOnly();
         }
 
-        private Task CreateDatabaseIfItDoesNotExist()
+        private async Task CreateDatabaseIfItDoesNotExist()
         {
-            return client.CreateDatabaseIfNotExistsAsync(new Database { Id = databaseName });
+            await client.CreateDatabaseIfNotExistsAsync(new Database { Id = databaseName });
         }
 
-        private Task CreateCollectionIfItDoesNotExist()
+        private async Task CreateCollectionIfItDoesNotExist()
         {
             var databaseUri = UriFactory.CreateDatabaseUri(databaseName);
 
-            var collection = new DocumentCollection
-            {
-                Id = collectionOptions.CollectionName,
-                DefaultTimeToLive = collectionOptions.DefaultTimeToLive
-            };
-
+            var collection = new DocumentCollection();
+            collection.Id = collectionOptions.CollectionName;
+            collection.DefaultTimeToLive = collectionOptions.DefaultTimeToLive;
             collection.PartitionKey.Paths.Add("/streamId");
             collection.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
             collection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/body/*" });
@@ -118,7 +115,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 OfferThroughput = collectionOptions.CollectionRequestUnits
             };
 
-            return client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
+            await client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, collection, requestOptions);
         }
 
         private async Task CreateAppendStoredProcedureIfItDoesNotExist()

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Azure.Documents;
 
 namespace SimpleEventStore.AzureDocumentDb

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Azure.Documents;
 
 namespace SimpleEventStore.AzureDocumentDb

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Runtime.Serialization;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.Azure.Documents;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.Serialization;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Azure.Documents;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
@@ -5,7 +5,7 @@
     <BuildVersion>1.0.0</BuildVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" Condition="'$(TargetFramework)' == 'net452'" />
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
   </ItemGroup>

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.1.2" Condition="'$(TargetFramework)' == 'net452'" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Initialising the CosmosDB Provider can now set throughput at a database level
Updating the RUs for a collection and Database will now overide the Cosmos offer 