### PR TITLE
Do not validate Database or Collection request units.

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -81,7 +81,10 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
                     collectionOptions.CollectionName = collectionName;
                     collectionOptions.CollectionRequestUnits = null;
                 },
-                databaseOptions => { databaseOptions.DatabaseRequestUnits = dbThroughput; });
+                databaseOptions =>
+                {
+                    databaseOptions.DatabaseRequestUnits = dbThroughput;
+                });
 
             await storageEngine.Initialise();
 

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -72,7 +72,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
         [Test]
         public async Task when_using_shared_throughput_it_is_set_at_a_database_level()
         {
-            const int throughput = 800;
+            const int dbThroughput = 800;
             var collectionName = "SharedCollection_" + Guid.NewGuid();
 
             var storageEngine = await StorageEngineFactory.Create(DatabaseName,
@@ -81,12 +81,14 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
                     collectionOptions.CollectionName = collectionName;
                     collectionOptions.CollectionRequestUnits = null;
                 },
-                databaseOptions => { databaseOptions.DatabaseRequestUnits = throughput; });
+                databaseOptions => { databaseOptions.DatabaseRequestUnits = dbThroughput; });
 
             await storageEngine.Initialise();
 
-            Assert.AreEqual(throughput, await GetDatabaseThroughput());
+            Assert.AreEqual(dbThroughput, await GetDatabaseThroughput());
+            Assert.AreEqual(null, await GetCollectionThroughput(collectionName));
         }
+
 
         [Test]
         public async Task when_throughput_is_set_offer_is_updated()
@@ -109,6 +111,55 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.AreEqual(collectionThroughput, await GetCollectionThroughput(collectionName));
         }
 
+        [TestCase(null, null, null, 400)]
+        [TestCase(600, null, 600, null)]
+        [TestCase(null, 600, null, 600)]
+        [TestCase(600, 600, 600, 600)]
+        [TestCase(600, 1000, 600, 1000)]
+        [TestCase(1000, 600, 1000, 600)]
+        public async Task set_database_and_collection_throughput_when_database_has_not_been_created(int? dbThroughput, int? collectionThroughput, int? expectedDbThroughput, int? expectedCollectionThroughput)
+        {
+            var collectionName = "CollectionThroughput_" + Guid.NewGuid();
+
+            var storageEngine = await StorageEngineFactory.Create(DatabaseName,
+                collectionOptions =>
+                {
+                    collectionOptions.CollectionName = collectionName;
+                    collectionOptions.CollectionRequestUnits = collectionThroughput;
+                },
+                databaseOptions =>
+                {
+                    databaseOptions.DatabaseRequestUnits = dbThroughput;
+                });
+
+            await storageEngine.Initialise();
+
+            Assert.AreEqual(expectedDbThroughput, await GetDatabaseThroughput());
+            Assert.AreEqual(expectedCollectionThroughput, await GetCollectionThroughput(collectionName));
+        }
+
+
+        [TestCase(null, 500, null)]
+        [TestCase(1000, 500, 1000)]
+        public async Task set_database_and_collection_throughput_when_database_has_already_been_created(int? collectionThroughput, int? expectedDbThroughput, int? expectedCollectionThroughput)
+        {
+            const int existingDbThroughput = 500;
+            await CreateDatabase(existingDbThroughput);
+            var collectionName = "CollectionThroughput_" + Guid.NewGuid();
+
+            var storageEngine = await StorageEngineFactory.Create(DatabaseName,
+                collectionOptions =>
+                {
+                    collectionOptions.CollectionName = collectionName;
+                    collectionOptions.CollectionRequestUnits = collectionThroughput;
+                });
+
+            await storageEngine.Initialise();
+
+            Assert.AreEqual(expectedDbThroughput, await GetDatabaseThroughput());
+            Assert.AreEqual(expectedCollectionThroughput, await GetCollectionThroughput(collectionName));
+        }
+
         private static async Task InitialiseStorageEngine(string collectionName, int collectionThroughput,
             int dbThroughput)
         {
@@ -123,23 +174,33 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             await storageEngine.Initialise();
         }
 
-        public async Task<int> GetCollectionThroughput(string collectionName)
+        public async Task<int?> GetCollectionThroughput(string collectionName)
         {
             var collection = await client.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(DatabaseName, collectionName));
 
             var collectionOffer = client.CreateOfferQuery().Where(x => x.ResourceLink == collection.Resource.SelfLink)
-                .AsEnumerable().First();
+                .AsEnumerable().FirstOrDefault();
 
-            return ((OfferV2)collectionOffer).Content.OfferThroughput;
+            return ((OfferV2) collectionOffer)?.Content.OfferThroughput;
         }
 
-        public async Task<int> GetDatabaseThroughput()
+        public async Task<int?> GetDatabaseThroughput()
         {
             var db = await client.ReadDatabaseAsync(databaseUri);
             var dbOffer = client.CreateOfferQuery().Where(x => x.ResourceLink == db.Resource.SelfLink).AsEnumerable()
-                .First();
+                .FirstOrDefault();
 
-            return ((OfferV2)dbOffer).Content.OfferThroughput;
+            return ((OfferV2)dbOffer)?.Content.OfferThroughput;
+        }
+
+        private Task CreateDatabase(int databaseRequestUnits)
+        {
+            return client.CreateDatabaseIfNotExistsAsync(
+                new Database { Id = DatabaseName },
+                new RequestOptions
+                {
+                    OfferThroughput = databaseRequestUnits
+                });
         }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbStorageEngineBuilderTests.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbStorageEngineBuilderTests.cs
@@ -54,26 +54,6 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.Throws<ArgumentNullException>(() => builder.UseJsonSerializerSettings(null));
         }
 
-        [Test]
-        public void throughput_must_be_set_in_one_location()
-        {
-            var builder = new AzureDocumentDbStorageEngineBuilder(CreateClient(), "Test")
-                .UseSharedThroughput(o => { o.DatabaseRequestUnits = null; })
-                .UseCollection(o => o.CollectionRequestUnits = null);
-
-            Assert.Throws<ArgumentException>(() => builder.Build());
-        }
-
-        [Test]
-        public void collection_throughput_cannot_be_greater_than_database_throughput()
-        {
-            var builder = new AzureDocumentDbStorageEngineBuilder(CreateClient(), "Test")
-                .UseSharedThroughput(o => { o.DatabaseRequestUnits = 400; })
-                .UseCollection(o => o.CollectionRequestUnits = 500);
-
-            Assert.Throws<ArgumentException>(() => builder.Build());
-        }
-
         private static DocumentClient CreateClient()
         {
             var client = new DocumentClient(new Uri("https://localhost:8081/"), "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
@@ -32,7 +32,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             var client = DocumentClientFactory.Create(settings);
 
             return new AzureDocumentDbStorageEngineBuilder(client, databaseName)
-                .UseSharedThroughput(o =>
+                .UseDatabase(o =>
                 {
                     databaseOverrides?.Invoke(o);
                 })

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
@@ -54,7 +54,7 @@ namespace SimpleEventStore.AzureDocumentDb
             return this;
         }
 
-        public AzureDocumentDbStorageEngineBuilder UseSharedThroughput(Action<DatabaseOptions> action)
+        public AzureDocumentDbStorageEngineBuilder UseDatabase(Action<DatabaseOptions> action)
         {
             Guard.IsNotNull(nameof(action), action);
 

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
@@ -64,16 +64,6 @@ namespace SimpleEventStore.AzureDocumentDb
 
         public IStorageEngine Build()
         {
-            if (this.collectionOptions.CollectionRequestUnits == null && this.databaseOptions.DatabaseRequestUnits == null)
-            {
-                throw new ArgumentException("Request units must be set in at least one location");
-            }
-
-            if (this.collectionOptions.CollectionRequestUnits > this.databaseOptions.DatabaseRequestUnits)
-            {
-                throw new ArgumentException("Unable to allocate more RUs to the collection than database");
-            }
-
             var engine = new AzureDocumentDbStorageEngine(this.client, this.databaseName, this.collectionOptions,this.databaseOptions, this.loggingOptions, this.typeMap, JsonSerializer.Create(this.jsonSerializerSettings));
             return engine;
         }


### PR DESCRIPTION
## Commit 1 - Do not validate database or collection request units

- Remove logic to validate that either database or collection units are set
- Remove logic to validate that a collection cannot have higher throughput than it's database

In a previous pull request #40 logic was added to validate that request units are set for either the collection or database. The same pull request also included logic to validate that collection units could not be higher than database units. This limits the ability of the user to configure the database and collection to their desired requirements and does not match with cosmos rules.

Cosmos does not require that request units are configured for the database or collection. If the user sets up the database with both Database and Collection throughput as null then cosmos will create a database without shared throughput and the collection will default to 400 RUs.

Cosmos also allows collections to be created with throughout greater than the database it belongs to.

This commit has removed the validation and includes a set of test cases to prove different combinations of storage engine setups both with and without an existing database.


## Commit 2 - Update UseSharedThroughput method name to UseDatabase
The name UseSharedThroughput is specific to database request units but the method allows users to also change options to other database settings

This commit updates the name of the method to be more inline with other builder method names