### PR TITLE
Added CancellationToken support to Event Store

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/IStorageEngine.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SimpleEventStore
 {
     public interface IStorageEngine
     {
-        Task AppendToStream(string streamId, IEnumerable<StorageEvent> events);
+        Task AppendToStream(string streamId, IEnumerable<StorageEvent> events, CancellationToken cancellationToken = default);
 
-        Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead);
+        Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead, CancellationToken cancellationToken = default);
 
-        Task<IStorageEngine> Initialise();
+        Task<IStorageEngine> Initialise(CancellationToken cancellationToken = default);
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SimpleEventStore.InMemory
@@ -12,7 +13,7 @@ namespace SimpleEventStore.InMemory
         private readonly ConcurrentDictionary<string, List<StorageEvent>> streams = new ConcurrentDictionary<string, List<StorageEvent>>();
         private readonly List<StorageEvent> allEvents = new List<StorageEvent>();
 
-        public Task AppendToStream(string streamId, IEnumerable<StorageEvent> events)
+        public Task AppendToStream(string streamId, IEnumerable<StorageEvent> events, CancellationToken cancellationToken = default)
         {
             return Task.Run(() =>
             {
@@ -41,7 +42,7 @@ namespace SimpleEventStore.InMemory
             }
         }
 
-        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead)
+        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead, CancellationToken cancellationToken = default)
         {
             if (!streams.ContainsKey(streamId))
             {
@@ -52,7 +53,7 @@ namespace SimpleEventStore.InMemory
             return Task.FromResult(stream);
         }
 
-        public Task<IStorageEngine> Initialise()
+        public Task<IStorageEngine> Initialise(CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IStorageEngine>(this);
         }


### PR DESCRIPTION
Added support for passing Cancellation Tokens down to the Cosmos SDK to allow for better control over timeouts.

Due to the addition of optional parameters, this is a runtime breaking change, but not a compile time one.

This is needed in order to better control Cosmos Timeout behaviour in various failure scenarios - see https://github.com/Azure/azure-cosmos-dotnet-v3/issues/959