### PR TITLE
Avoid corrupting stack for non concurrency cosmos errors

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngine.cs
@@ -64,14 +64,9 @@ namespace SimpleEventStore.AzureDocumentDb
 
                 loggingOptions.OnSuccess(ResponseInformation.FromWriteResponse(nameof(AppendToStream), result));
             }
-            catch (DocumentClientException ex)
+            catch (DocumentClientException ex) when (ex.Error.Message.Contains(ConcurrencyConflictErrorKey))
             {
-                if (ex.Error.Message.Contains(ConcurrencyConflictErrorKey))
-                {
-                    throw new ConcurrencyException(ex.Error.Message, ex);
-                }
-
-                throw;
+                throw new ConcurrencyException(ex.Error.Message, ex);
             }
         }
 


### PR DESCRIPTION
Use an exception filter to avoid modifying the stack when a `DocumentClientException` is thrown that isn't a concurrency error.