### PR TITLE
Added support for cancellation token to EventStore

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SimpleEventStore.Tests.Events;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SimpleEventStore.Tests
 {
@@ -62,6 +63,22 @@ namespace SimpleEventStore.Tests
 
             Assert.That(events.Count, Is.EqualTo(1));
             Assert.That(events.First().EventBody, Is.InstanceOf<OrderDispatched>());
+        }
+
+        [Test]
+        public async Task when_reading_a_stream_the_engine_honours_cancellation_token()
+        {
+            var streamId = Guid.NewGuid().ToString();
+            var subject = await GetEventStore();
+
+            using (var cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                AsyncTestDelegate act = () => subject.ReadStreamForwards(streamId, cts.Token);
+
+                Assert.That(act, Throws.InstanceOf<OperationCanceledException>());
+            }
         }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore/EventStore.cs
+++ b/src/SimpleEventStore/SimpleEventStore/EventStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SimpleEventStore
@@ -15,6 +16,11 @@ namespace SimpleEventStore
 
         public Task AppendToStream(string streamId, int expectedVersion, params EventData[] events)
         {
+            return AppendToStream(streamId, expectedVersion, default, events);
+        }
+
+        public Task AppendToStream(string streamId, int expectedVersion, CancellationToken cancellationToken, params EventData[] events)
+        {
             Guard.IsNotNullOrEmpty(nameof(streamId), streamId);
 
             var storageEvents = new List<StorageEvent>();
@@ -25,21 +31,21 @@ namespace SimpleEventStore
                 storageEvents.Add(new StorageEvent(streamId, events[i], ++eventVersion));
             }
 
-            return engine.AppendToStream(streamId, storageEvents);
+            return engine.AppendToStream(streamId, storageEvents, cancellationToken);
         }
 
-        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId)
+        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, CancellationToken cancellationToken = default)
         {
             Guard.IsNotNullOrEmpty(nameof(streamId), streamId);
 
-            return engine.ReadStreamForwards(streamId, 1, Int32.MaxValue);
+            return engine.ReadStreamForwards(streamId, 1, Int32.MaxValue, cancellationToken);
         }
 
-        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead)
+        public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead, CancellationToken cancellationToken = default)
         {
             Guard.IsNotNullOrEmpty(nameof(streamId), streamId);
 
-            return engine.ReadStreamForwards(streamId, startPosition, numberOfEventsToRead);
+            return engine.ReadStreamForwards(streamId, startPosition, numberOfEventsToRead, cancellationToken);
         }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore/InMemory/InMemoryStorageEngine.cs
@@ -29,6 +29,8 @@ namespace SimpleEventStore.InMemory
                     throw new ConcurrencyException($"Concurrency conflict when appending to stream {streamId}. Expected revision {firstEvent.EventNumber} : Actual revision {streams[streamId].Count}");
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
+
                 streams[streamId].AddRange(events);
                 AddEventsToAllStream(events);
             });
@@ -44,6 +46,8 @@ namespace SimpleEventStore.InMemory
 
         public Task<IReadOnlyCollection<StorageEvent>> ReadStreamForwards(string streamId, int startPosition, int numberOfEventsToRead, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!streams.ContainsKey(streamId))
             {
                 return Task.FromResult(EmptyStream);
@@ -55,6 +59,8 @@ namespace SimpleEventStore.InMemory
 
         public Task<IStorageEngine> Initialise(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             return Task.FromResult<IStorageEngine>(this);
         }
     }


### PR DESCRIPTION
Extended recent change which added cancellation token support to storage engine. `EventStore` now allows consumer to pass cancellation token and this is passed on to the configured storage engine. Also added a couple of tests around this to ensure that future engines are forced to implement cancellation token support.