### PR TITLE
Refactor Tests

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
@@ -32,7 +32,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
         protected override Task<IStorageEngine> CreateStorageEngine()
         {
             return StorageEngineFactory.Create("JsonSerializationSettingsTests",
-                new JsonSerializerSettings
+                settings: new JsonSerializerSettings
                 {
                     Converters = new List<JsonConverter>
                     {

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppendingWithConverters.cs
@@ -17,12 +17,11 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
         public async Task when_appending_an_event_that_requires_a_converter_the_event_is_saved_and_read()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var @event = new EventData(Guid.NewGuid(), new OrderProcessed(streamId, new Version(1, 2, 0)));
             
-            await subject.AppendToStream(streamId, 0, @event);
+            await Subject.AppendToStream(streamId, 0, @event);
 
-            var stream = await subject.ReadStreamForwards(streamId);
+            var stream = await Subject.ReadStreamForwards(streamId);
             Assert.That(stream.Count, Is.EqualTo(1));
             Assert.That(stream.Single().StreamId, Is.EqualTo(streamId));
             Assert.That(stream.Single().EventId, Is.EqualTo(@event.EventId));

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
@@ -40,36 +40,9 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             Assert.That(logCount, Is.EqualTo(2));
         }
 
-        private static Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string databaseName = "LoggingTests")
+        private static Task<IStorageEngine> CreateStorageEngine(Action<ResponseInformation> onSuccessCallback, string collectionName = "LoggingTests")
         {
-            var config = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .AddEnvironmentVariables()
-                .Build();
-
-            var documentDbUri = config["Uri"];
-            var authKey = config["AuthKey"];
-            var consistencyLevel = config["ConsistencyLevel"];
-
-            if (!Enum.TryParse(consistencyLevel, true, out ConsistencyLevel consistencyLevelEnum))
-            {
-                throw new Exception($"The ConsistencyLevel value {consistencyLevel} is not supported");
-            }
-
-            DocumentClient client = new DocumentClient(new Uri(documentDbUri), authKey);
-
-            return new AzureDocumentDbStorageEngineBuilder(client, databaseName)
-                .UseCollection(o =>
-                {
-                    o.ConsistencyLevel = consistencyLevelEnum;
-                    o.CollectionRequestUnits = 400;
-                })
-                .UseLogging(o =>
-                {
-                    o.Success = onSuccessCallback;
-                })
-                .Build()
-                .Initialise();
+            return StorageEngineFactory.Create("LoggingTests", builderOverrides: x => x.UseLogging(o => o.Success = onSuccessCallback));
         }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreReadingPartiallyDeletedStreams.cs
@@ -14,15 +14,14 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
         [Test]
         public async Task when_reading_a_stream_that_has_deleted_events_the_stream_can_still_be_read()
         {
-            const string databaseName = "ReadingPartialStreamTests";
-            const string collectionName = "Commits";
+            const string collectionName = "ReadingPartialStreamTests";
 
             var client = DocumentClientFactory.Create();
-            var storageEngine = await StorageEngineFactory.Create(databaseName, o => o.CollectionName = collectionName);
+            var storageEngine = await StorageEngineFactory.Create(collectionName);
             var eventStore = new EventStore(storageEngine);
             var streamId = Guid.NewGuid().ToString();
             await eventStore.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)), new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
-            await SimulateTimeToLiveExpiration(databaseName, collectionName, client, streamId);
+            await SimulateTimeToLiveExpiration(StorageEngineFactory.DefaultDatabaseName, collectionName, client, streamId);
 
             var stream = await eventStore.ReadStreamForwards(streamId);
 

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
@@ -9,7 +9,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.1" />    

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/TestConstants.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/TestConstants.cs
@@ -2,7 +2,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
 {
     internal static class TestConstants
     {
-        internal const int RequestUnits = 400;
+        internal const int RequestUnits = 500;
         internal const string AppendStoredProcedureName = "appendToStream";
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreAppending.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreAppending.cs
@@ -14,12 +14,11 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_a_new_stream_the_event_is_saved()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var @event = new EventData(Guid.NewGuid(), new OrderCreated(streamId));
             
-            await subject.AppendToStream(streamId, 0, @event);
+            await Subject.AppendToStream(streamId, 0, @event);
 
-            var stream = await subject.ReadStreamForwards(streamId);
+            var stream = await Subject.ReadStreamForwards(streamId);
             Assert.That(stream.Count, Is.EqualTo(1));
             Assert.That(stream.Single().StreamId, Is.EqualTo(streamId));
             Assert.That(stream.Single().EventId, Is.EqualTo(@event.EventId));
@@ -30,13 +29,12 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_an_existing_stream_the_event_is_saved()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
-            await subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+            await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
             var @event = new EventData(Guid.NewGuid(), new OrderDispatched(streamId));
 
-            await subject.AppendToStream(streamId, 1, @event);
+            await Subject.AppendToStream(streamId, 1, @event);
 
-            var stream = await subject.ReadStreamForwards(streamId);
+            var stream = await Subject.ReadStreamForwards(streamId);
             Assert.That(stream.Count, Is.EqualTo(2));
             Assert.That(stream.Skip(1).Single().EventId, Is.EqualTo(@event.EventId));
             Assert.That(stream.Skip(1).Single().EventNumber, Is.EqualTo(2));
@@ -48,10 +46,9 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_a_new_stream_with_an_unexpected_version__a_concurrency_error_is_thrown(int expectedVersion)
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var @event = new EventData(Guid.NewGuid(), new OrderDispatched(streamId));
 
-            Assert.ThrowsAsync<ConcurrencyException>(async () => await subject.AppendToStream(streamId, expectedVersion, @event));
+            Assert.ThrowsAsync<ConcurrencyException>(async () => await Subject.AppendToStream(streamId, expectedVersion, @event));
         }
 
         [Test]
@@ -60,12 +57,11 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_an_existing_stream_with_an_unexpected_version_a_concurrency_error_is_thrown(int expectedVersion)
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
-            await subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+            await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
 
             var @event = new EventData(Guid.NewGuid(), new OrderDispatched(streamId));
 
-            Assert.ThrowsAsync<ConcurrencyException>(async () => await subject.AppendToStream(streamId, expectedVersion, @event));
+            Assert.ThrowsAsync<ConcurrencyException>(async () => await Subject.AppendToStream(streamId, expectedVersion, @event));
         }
 
         [Test]
@@ -74,24 +70,22 @@ namespace SimpleEventStore.Tests
         [TestCase(" ")]
         public async Task when_appending_to_an_invalid_stream_id_an_argument_error_is_thrown(string streamId)
         {
-            var eventStore = await GetEventStore();
-            Assert.ThrowsAsync<ArgumentException>(async () => await eventStore.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId))));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId))));
         }
 
         [Test]
         public async Task when_appending_to_a_new_stream_with_multiple_events_then_they_are_saved()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var events = new []
             {
                 new EventData(Guid.NewGuid(), new OrderCreated(streamId)),
                 new EventData(Guid.NewGuid(), new OrderDispatched(streamId))
             };
 
-            await subject.AppendToStream(streamId, 0, events);
+            await Subject.AppendToStream(streamId, 0, events);
 
-            var savedEvents = await subject.ReadStreamForwards(streamId);
+            var savedEvents = await Subject.ReadStreamForwards(streamId);
 
             Assert.That(savedEvents.Count, Is.EqualTo(2));
             Assert.That(savedEvents.First().StreamId, Is.EqualTo(streamId));
@@ -104,13 +98,12 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_a_new_stream_the_event_metadata_is_saved()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var metadata = new TestMetadata { Value = "Hello" };
             var @event = new EventData(Guid.NewGuid(), new OrderCreated(streamId), metadata);
 
-            await subject.AppendToStream(streamId, 0, @event);
+            await Subject.AppendToStream(streamId, 0, @event);
 
-            var stream = await subject.ReadStreamForwards(streamId);
+            var stream = await Subject.ReadStreamForwards(streamId);
             Assert.That(((TestMetadata)stream.Single().Metadata).Value, Is.EqualTo(metadata.Value));
         }
 
@@ -118,7 +111,6 @@ namespace SimpleEventStore.Tests
         public async Task when_appending_to_a_stream_the_engine_honours_cancellation_token()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
             var metadata = new TestMetadata { Value = "Hello" };
             var @event = new EventData(Guid.NewGuid(), new OrderCreated(streamId), metadata);
 
@@ -126,7 +118,7 @@ namespace SimpleEventStore.Tests
             {
                 cts.Cancel();
 
-                AsyncTestDelegate act = () => subject.AppendToStream(streamId, 0, cts.Token, @event);
+                AsyncTestDelegate act = () => Subject.AppendToStream(streamId, 0, cts.Token, @event);
 
                 Assert.That(act, Throws.InstanceOf<OperationCanceledException>());
             }

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
@@ -17,9 +17,8 @@ namespace SimpleEventStore.Tests
         public async Task when_reading_a_stream_which_has_no_events_an_empty_list_is_returned()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
 
-            var events = await subject.ReadStreamForwards(streamId);
+            var events = await Subject.ReadStreamForwards(streamId);
 
             Assert.That(events.Count, Is.EqualTo(0));
         }
@@ -28,12 +27,11 @@ namespace SimpleEventStore.Tests
         public async Task when_reading_a_stream_all_events_are_returned()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
 
-            await subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
-            await subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
+            await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+            await Subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
 
-            var events = await subject.ReadStreamForwards(streamId);
+            var events = await Subject.ReadStreamForwards(streamId);
 
             Assert.That(events.Count, Is.EqualTo(2));
             Assert.That(events.First().EventBody, Is.InstanceOf<OrderCreated>());
@@ -46,20 +44,18 @@ namespace SimpleEventStore.Tests
         [TestCase(" ")]
         public async Task when_reading_from_an_invalid_stream_id_an_argument_error_is_thrown(string streamId)
         {
-            var eventStore = await GetEventStore();
-            Assert.ThrowsAsync<ArgumentException>(async () => await eventStore.ReadStreamForwards(streamId));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Subject.ReadStreamForwards(streamId));
         }
 
         [Test]
         public async Task when_reading_a_stream_only_the_required_events_are_returned()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
 
-            await subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
-            await subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
+            await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+            await Subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
 
-            var events = await subject.ReadStreamForwards(streamId, startPosition: 2, numberOfEventsToRead: 1);
+            var events = await Subject.ReadStreamForwards(streamId, startPosition: 2, numberOfEventsToRead: 1);
 
             Assert.That(events.Count, Is.EqualTo(1));
             Assert.That(events.First().EventBody, Is.InstanceOf<OrderDispatched>());
@@ -69,13 +65,12 @@ namespace SimpleEventStore.Tests
         public async Task when_reading_a_stream_the_engine_honours_cancellation_token()
         {
             var streamId = Guid.NewGuid().ToString();
-            var subject = await GetEventStore();
 
             using (var cts = new CancellationTokenSource())
             {
                 cts.Cancel();
 
-                AsyncTestDelegate act = () => subject.ReadStreamForwards(streamId, cts.Token);
+                AsyncTestDelegate act = () => Subject.ReadStreamForwards(streamId, cts.Token);
 
                 Assert.That(act, Throws.InstanceOf<OperationCanceledException>());
             }

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreTestBase.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreTestBase.cs
@@ -1,14 +1,19 @@
+using NUnit.Framework;
 using System.Threading.Tasks;
 
 namespace SimpleEventStore.Tests
 {
     public abstract class EventStoreTestBase
     {
-        protected async Task<EventStore> GetEventStore()
+        protected EventStore Subject { get; private set; }
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
         {
             var storageEngine = await CreateStorageEngine();
-            return new EventStore(storageEngine);
+            Subject = new EventStore(storageEngine);
         }
+
 
         protected abstract Task<IStorageEngine> CreateStorageEngine();
     }


### PR DESCRIPTION
* Create all test collections under a single database so all the test collections are in a single location in the Cosmos Explorer.  (Exception is the Initalisation tests which still need to create a new database / collection each time)
* Provision test collections with database level shared RUs by default to reduce costs if they're left in a live cosmos instance
* Create `EventStore` once per test to avoid expensive initialisation in the cosmos tests
* Remove an unneeded reference from the Cosmos test project.