### PR TITLE
Optimise append stored procedure

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
 using NUnit.Framework;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
@@ -32,13 +30,20 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
 
             var database = (await client.ReadDatabaseAsync(databaseUri)).Resource;
             var collection = (await client.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(DatabaseName, collectionName))).Resource;
-            var storedProcedure = (await client.ReadStoredProcedureAsync(UriFactory.CreateStoredProcedureUri(DatabaseName, collectionName, TestConstants.AppendStoredProcedureName))).Resource;
+
+            var storedProcedure = client.CreateStoredProcedureQuery(collection.SelfLink)
+                .Where(r => r.Id.StartsWith("appendToStream-"))
+                .AsEnumerable()
+                .OfType<StoredProcedure>()
+                .Single();
+
             var offer = client.CreateOfferQuery()
                 .Where(r => r.ResourceLink == collection.SelfLink)
                 .AsEnumerable()
                 .OfType<OfferV2>()
                 .Single();
 
+            Assert.That(storedProcedure, Is.Not.Null);
             Assert.That(offer.Content.OfferThroughput, Is.EqualTo(TestConstants.RequestUnits));
             Assert.That(collection.DefaultTimeToLive, Is.Null);
             Assert.That(collection.PartitionKey.Paths.Count, Is.EqualTo(1));

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/TestConstants.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb.Tests/TestConstants.cs
@@ -3,6 +3,5 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
     internal static class TestConstants
     {
         internal const int RequestUnits = 400;
-        internal const string AppendStoredProcedureName = "appendToStream";
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AppendSprocProvider.cs
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/AppendSprocProvider.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SimpleEventStore.AzureDocumentDb
+{
+    internal static class AppendSprocProvider
+    {
+        public static (string Name, string Body) GetAppendSprocData()
+        {
+            var body = Resources.GetString("appendToStream.js");
+            var version = CalculateVersion(body);
+            var name = "appendToStream-" + version;
+
+            return (name, body);
+        }
+
+        private static string CalculateVersion(string body)
+        {
+            var bytes = Encoding.Unicode.GetBytes(body);
+
+            using (var hashAlgorithm = new SHA1CryptoServiceProvider())
+            {
+                var hashBytes = hashAlgorithm.ComputeHash(bytes);
+
+                var versionChars = bytes
+                    .Take(4)
+                    .Select(x => x.ToString("X2"));
+
+                return string.Concat(versionChars);
+            }
+        }
+
+    }
+}

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
@@ -4,7 +4,7 @@ function appendToStream(events) {
     var streamId = events[0].streamId;
     var firstEventNumber = events[0].eventNumber;
 
-    if (firstEventNumber == 1) {
+    if (firstEventNumber === 1) {
         createEvents();
     }
     else {
@@ -23,7 +23,7 @@ function appendToStream(events) {
 
         function onPreviousEventCompleted(err, doc, options) {
             if (err) {
-                if (err.number == 404) {
+                if (err.number === 404) {
                     throw new Error(409, "Previous Event" + previousEventNumber + " not found for stream '" + streamId + "'")
                 }
                 throw err;
@@ -48,7 +48,7 @@ function appendToStream(events) {
 
         function onDocumentCreated(err, doc, options) {
             if (err) {
-                if (err.number == 409) {
+                if (err.number === 409) {
                     throw new Error(409, "Failed to create event at index " + index + ". Event Number " + events[index].eventNumber + " already exists for stream '" + streamId + "'")
                 }
                 throw err;

--- a/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
+++ b/src/SimpleEventStore/SimpleEventStore.AzureDocumentDb/Resources/appendToStream.js
@@ -1,49 +1,63 @@
-function appendToStream(documents) {
+function appendToStream(events) {
     var context = getContext();
     var collection = context.getCollection();
-    var collectionLink = collection.getSelfLink();
-    var streamId = documents[0].streamId;
-    var expectedEventNumber = documents[0].eventNumber - 1;
+    var streamId = events[0].streamId;
+    var firstEventNumber = events[0].eventNumber;
 
-    var concurrencyQuery = {
-        query: "SELECT TOP 1 c.eventNumber FROM Commits c WHERE c.streamId = @streamId ORDER BY c.eventNumber DESC",
-        parameters: [{ name: "@streamId", value: streamId }]
-    };
-
-    var accepted = collection.queryDocuments(collectionLink, concurrencyQuery, {}, onConcurrencyQueryCompleted);
-
-    if (!accepted) throw new Error("Concurrency query not accepted.");
-
-    function onConcurrencyQueryCompleted(err, doc, options) {
-        if (err) throw err;
-
-        var actualEventNumber = doc.length > 0 ? doc[0].eventNumber : 0;
-
-        if (actualEventNumber !== expectedEventNumber) {
-            throw new Error("Concurrency conflict. Expected revision " + expectedEventNumber + ", actual " + actualEventNumber + ")");
-        }
-
-        createDocuments();
+    if (firstEventNumber == 1) {
+        createEvents();
+    }
+    else {
+        createEventsOnlyIfPreviousEventExists();
     }
 
-    function createDocuments() {
+    function createEventsOnlyIfPreviousEventExists() {
+        var previousEventNumber = firstEventNumber - 1;
+        var previousDocId = streamId + ":" + previousEventNumber;
+        var previousDocLink = collection.getAltLink() + '/docs/' + previousDocId;
+
+        var isAccepted = collection.readDocument(previousDocLink, {}, onPreviousEventCompleted);
+        if (!isAccepted) {
+            throw new Error(500, "Existing event read not accepted for creation.");
+        }
+
+        function onPreviousEventCompleted(err, doc, options) {
+            if (err) {
+                if (err.number == 404) {
+                    throw new Error(409, "Previous Event" + previousEventNumber + " not found for stream '" + streamId + "'")
+                }
+                throw err;
+            }
+
+            createEvents();
+        }
+    }
+
+    function createEvents() {
         var index = 0;
-        createDocument(documents[index]);
+        var collectionLink = collection.getSelfLink();
+        createDocument(events[index]);
 
-        // NOTE: isAccepted states if the write is going to be processed
         function createDocument(document) {
-            var accepted = collection.createDocument(collectionLink, document, onDocumentCreated);
+            var isAccepted = collection.createDocument(collectionLink, document, onDocumentCreated);
 
-            if (!accepted) throw new Error("Document not accepted for creation.");
+            if (!isAccepted) {
+                throw new Error(500, "Event at index " + index + "not accepted for creation.");
+            }
         }
 
         function onDocumentCreated(err, doc, options) {
-            if (err) throw err;
+            if (err) {
+                if (err.number == 409) {
+                    throw new Error(409, "Failed to create event at index " + index + ". Event Number " + events[index].eventNumber + " already exists for stream '" + streamId + "'")
+                }
+                throw err;
+            }
 
             index++;
 
-            if (index < documents.length) {
-                createDocument(documents[index]);
+            if (index < events.length) {
+                createDocument(events[index]);
             }
             else {
                 context.getResponse().setBody("Events written successfully");


### PR DESCRIPTION
Reduced RU consumption of the append stored procedure by reworking the sproc to use a document lookup rather than a query.  In testing this typically reduced the sproc cost by roughly .5-2 units (e.g. writing a single event dropped from 12.3 to 10.2).  RU Usage by sprocs is particularly important as they achieve atomicity by running on the master node of a partition, which means they can start throttling after consuming only a fraction of the available RUs.

To better support gradual roll out / roll back scenarios, the sproc name is now versioned - an 8 character hash is appended to teh name of the sproc based on the contents.  If the sproc contents change, so to will the expected sproc name, which will cause the library to create a new version of the sproc.