### PR TITLE
Optimise Read Query

### DIFF
--- a/src/SimpleEventStore/Directory.Build.props
+++ b/src/SimpleEventStore/Directory.Build.props
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/AzureCosmosDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/AzureCosmosDbStorageEngine.cs
@@ -93,7 +93,7 @@ namespace SimpleEventStore.CosmosDb
                     FROM e
                     WHERE e.streamId = @StreamId
                         AND (e.eventNumber BETWEEN @LowerBound AND @UpperBound)
-                    ORDER BY e.streamId ASC"
+                    ORDER BY e.eventNumber ASC"
                 )
                 .WithParameter("@StreamId", streamId)
                 .WithParameter("@LowerBound", startPosition)

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SimpleEventStore.CosmosDb</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/EventStoreReading.cs
@@ -39,6 +39,23 @@ namespace SimpleEventStore.Tests
         }
 
         [Test]
+        public async Task when_reading_a_stream_events_returned_in_correct_order()
+        {
+            var streamId = Guid.NewGuid().ToString();
+
+            await Subject.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+            await Subject.AppendToStream(streamId, 1, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
+            await Subject.AppendToStream(streamId, 2, new EventData(Guid.NewGuid(), new OrderDispatched(streamId)));
+
+            var events = await Subject.ReadStreamForwards(streamId);
+
+            Assert.That(events.Count, Is.EqualTo(3));
+            Assert.That(events.First().EventNumber, Is.EqualTo(1));
+            Assert.That(events.Skip(1).First().EventNumber, Is.EqualTo(2));
+            Assert.That(events.Skip(2).First().EventNumber, Is.EqualTo(3));
+        }
+
+        [Test]
         [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]


### PR DESCRIPTION
* Converted the query from LINQ to a direct SQL query.  In profiling our
  application, under high loads we were seeing up 10-12% of CPU time
  being spent converting the read query from LINQ to SQL.

* Upgraded minimum SDK version to 3.10.1 to fix a memory link by
  disposing of the query correctly

