### PR TITLE
Use autoscale option as default in throughput properties

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/TestConstants.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/TestConstants.cs
@@ -2,6 +2,6 @@ namespace SimpleEventStore.CosmosDb.Tests
 {
     internal static class TestConstants
     {
-        internal const int RequestUnits = 500;
+        internal const int RequestUnits = 5000;
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/AzureCosmosDbStorageEngine.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/AzureCosmosDbStorageEngine.cs
@@ -47,7 +47,6 @@ namespace SimpleEventStore.CosmosDb
             cancellationToken.ThrowIfCancellationRequested();
             await Task.WhenAll(
                 InitialiseStoredProcedure(),
-                SetDatabaseOfferThroughput(),
                 SetCollectionOfferThroughput()
             );
 
@@ -172,14 +171,6 @@ namespace SimpleEventStore.CosmosDb
             if (collectionOptions.CollectionRequestUnits != null)
             {
                 await _collection.ReplaceThroughputAsync(ThroughputProperties.CreateAutoscaleThroughput((int)collectionOptions.CollectionRequestUnits));
-            }
-        }
-
-        private async Task SetDatabaseOfferThroughput()
-        {
-            if (_databaseOptions.DatabaseRequestUnits != null)
-            {
-                await _database.ReplaceThroughputAsync(ThroughputProperties.CreateAutoscaleThroughput((int)_databaseOptions.DatabaseRequestUnits));
             }
         }
     }


### PR DESCRIPTION
Use autoscale option as default in throughput properties in CosmosDb collections and database