### PR TITLE
Added autoscale option support

### DIFF
--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/CosmosDbStorageEngineFactory.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/CosmosDbStorageEngineFactory.cs
@@ -15,7 +15,7 @@ namespace SimpleEventStore.CosmosDb.Tests
         internal static Task<IStorageEngine> Create(string collectionName, string databaseName = null, Action<AzureCosmosDbStorageEngineBuilder> builderOverrides = null, JsonSerializerSettings settings = null)
         {
             settings = settings ?? new JsonSerializerSettings();
-            
+
             databaseName = databaseName ?? DefaultDatabaseName;
 
             var config = new ConfigurationBuilder()
@@ -35,7 +35,7 @@ namespace SimpleEventStore.CosmosDb.Tests
             var builder = new AzureCosmosDbStorageEngineBuilder(client, databaseName)
                 .UseDatabase(o =>
                 {
-                    o.DatabaseRequestUnits = TestConstants.RequestUnits;
+                    o.DatabaseRequestUnits = 5000;
                 })
                 .UseCollection(o =>
                 {

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/TestConstants.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/TestConstants.cs
@@ -1,7 +1,0 @@
-namespace SimpleEventStore.CosmosDb.Tests
-{
-    internal static class TestConstants
-    {
-        internal const int RequestUnits = 500;
-    }
-}

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/CollectionOptions.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/CollectionOptions.cs
@@ -17,6 +17,8 @@ namespace SimpleEventStore.CosmosDb
 
         public int? CollectionRequestUnits { get; set; }
 
+        public bool UseAutoscale { get; set; }
+
         public int? DefaultTimeToLive { get; set; }
     }
 }

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/DatabaseOptions.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/DatabaseOptions.cs
@@ -2,6 +2,8 @@
 {
     public class DatabaseOptions
     {
-        public int? DatabaseRequestUnits {get; set;}
+        public int? DatabaseRequestUnits { get; set; }
+
+        public bool UseAutoscale { get; set; }
     }
 }


### PR DESCRIPTION
Added autoscale option support into collection and database options, so contributor can choose which scale model to use - Auto or Manual.

Manual scale model used as default, so package is compatible with previous versions.