### PR TITLE
Updated Azure pipelines to use support images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
 - master
 
 pool:
-  vmImage: ubuntu-latest
+  vmImage: windows-2019
 stages:
 - stage: Build
   displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,13 +14,15 @@ stages:
   jobs:
   - job: Build
     steps:
-      - task: CosmosDbEmulator@2
+      - task: PowerShell@2
+        displayName: 'Starting Cosmos Emulator'
         inputs:
-          containerName: 'azure-cosmosdb-emulator'
-          enableAPI: 'SQL'
-          portMapping: '8081:8081, 8901:8901, 8902:8902, 8979:8979, 10250:10250, 10251:10251, 10252:10252, 10253:10253, 10254:10254, 10255:10255, 10256:10256, 10350:10350'
-          hostDirectory: '$(Build.BinariesDirectory)\azure-cosmosdb-emulator'
-          consistency: 'BoundedStaleness'
+          targetType: 'inline'
+          workingDirectory: $(Pipeline.Workspace)
+          script: |
+            Write-Host "Starting CosmosDB Emulator"
+            Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+            Start-CosmosDbEmulator
       - task: PowerShell@2
         inputs:
           filePath: '.\build.ps1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,6 @@ stages:
       - task: PowerShell@2
         inputs:
           filePath: '.\build.ps1'
-          arguments: '-Uri $(CosmosDbEmulator.Endpoint)'
       - task: PublishTestResults@2
         condition: succeededOrFailed()
         inputs:


### PR DESCRIPTION
## Purpose
The old agent image was unsupported, failing the pipeline.

## Approach
Updates from Win2016 to Win2019
