### PR TITLE
Nuget Package Updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 - main
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-latest
 stages:
 - stage: Build
   displayName: Build

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreInitializing.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreInitializing.cs
@@ -46,11 +46,11 @@ namespace SimpleEventStore.CosmosDb.Tests
         {
             const int dbThroughput = 800;
             var collectionName = "SharedCollection_" + Guid.NewGuid();
+            
+            await InitialiseStorageEngine(collectionName, dbThroughput: dbThroughput);
 
-            var storageEngine = await InitialiseStorageEngine(collectionName, dbThroughput: dbThroughput);
-
-            Assert.AreEqual(dbThroughput, await GetDatabaseThroughput());
-            Assert.AreEqual(null, await GetCollectionThroughput(collectionName));
+            Assert.That(dbThroughput, Is.EqualTo(await GetDatabaseThroughput()));
+            Assert.That(await GetCollectionThroughput(collectionName), Is.Null);
         }
 
         [TestCase(60)]
@@ -82,16 +82,16 @@ namespace SimpleEventStore.CosmosDb.Tests
 
             await InitialiseStorageEngine(collectionName, collectionThroughput, dbThroughput);
 
-            Assert.AreEqual(dbThroughput, await GetDatabaseThroughput());
-            Assert.AreEqual(collectionThroughput, await GetCollectionThroughput(collectionName));
+            Assert.That(dbThroughput, Is.EqualTo(await GetDatabaseThroughput()));
+            Assert.That(collectionThroughput, Is.EqualTo(await GetCollectionThroughput(collectionName)));
 
             dbThroughput = 1600;
             collectionThroughput = 800;
 
             await InitialiseStorageEngine(collectionName, collectionThroughput, dbThroughput);
 
-            Assert.AreEqual(dbThroughput, await GetDatabaseThroughput());
-            Assert.AreEqual(collectionThroughput, await GetCollectionThroughput(collectionName));
+            Assert.That(dbThroughput, Is.EqualTo(await GetDatabaseThroughput()));
+            Assert.That(collectionThroughput, Is.EqualTo(await GetCollectionThroughput(collectionName)));
         }
 
         [TestCase(null, null, null, 400)]
@@ -104,11 +104,10 @@ namespace SimpleEventStore.CosmosDb.Tests
         {
             var collectionName = "CollectionThroughput_" + Guid.NewGuid();
 
+            await InitialiseStorageEngine(collectionName, collectionThroughput, dbThroughput);
 
-            var storageEngine = await InitialiseStorageEngine(collectionName, collectionThroughput, dbThroughput);
-
-            Assert.AreEqual(expectedDbThroughput, await GetDatabaseThroughput());
-            Assert.AreEqual(expectedCollectionThroughput, await GetCollectionThroughput(collectionName));
+            Assert.That(expectedDbThroughput, Is.EqualTo(await GetDatabaseThroughput()));
+            Assert.That(expectedCollectionThroughput, Is.EqualTo(await GetCollectionThroughput(collectionName)));
         }
 
 
@@ -120,10 +119,10 @@ namespace SimpleEventStore.CosmosDb.Tests
             await CreateDatabase(existingDbThroughput);
             var collectionName = "CollectionThroughput_" + Guid.NewGuid();
 
-            var storageEngine = await InitialiseStorageEngine(collectionName, collectionThroughput, null);
+            await InitialiseStorageEngine(collectionName, collectionThroughput, null);
 
-            Assert.AreEqual(expectedDbThroughput, await GetDatabaseThroughput());
-            Assert.AreEqual(expectedCollectionThroughput, await GetCollectionThroughput(collectionName));
+            Assert.That(expectedDbThroughput, Is.EqualTo(await GetDatabaseThroughput()));
+            Assert.That(expectedCollectionThroughput, Is.EqualTo(await GetCollectionThroughput(collectionName)));
         }
 
         private static async Task<IStorageEngine> InitialiseStorageEngine(string collectionName, int? collectionThroughput = null,

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreLogging.cs
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreLogging.cs
@@ -17,7 +17,7 @@ namespace SimpleEventStore.CosmosDb.Tests
 
             await sut.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated("TEST-ORDER")));
 
-            Assert.NotNull(response);
+            Assert.That(response, Is.Not.Null);
             await TestContext.Out.WriteLineAsync($"Charge: {response.RequestCharge}");
             await TestContext.Out.WriteLineAsync($"Quota Usage: {response.CurrentResourceQuotaUsage}");
             await TestContext.Out.WriteLineAsync($"Max Resource Quote: {response.MaxResourceQuota}");

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <Title>SimpleEventStore.CosmosDb.Tests</Title>
     <Company>ASOS</Company>
-    <Copyright>Copyright ASOS © 2020</Copyright>
+    <Copyright>Copyright ASOS © 2024</Copyright>
     <Product>SimpleEventStore.CosmosDb.Tests</Product>
   </PropertyGroup>
 </Project>

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
@@ -10,12 +10,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />    
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore.CosmosDb\SimpleEventStore.CosmosDb.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>SimpleEventStore.CosmosDb.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SimpleEventStore.CosmosDb</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj
@@ -15,7 +15,7 @@
     <Title>Asos.SimpleEventStore.CosmosDb</Title>
     <Description>Uses Azure Cosmos DB as the stream database for Simple Event Store (SES)</Description>
     <Company>ASOS</Company>
-    <Copyright>Copyright ASOS © 2023</Copyright>
+    <Copyright>Copyright ASOS © 2024</Copyright>
     <Product>SimpleEventStore.CosmosDb</Product>
     <PackageId>Asos.SimpleEventStore.CosmosDb</PackageId>
     <Authors>ASOS</Authors>

--- a/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
@@ -7,9 +7,9 @@
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <PropertyGroup>
     <Title>SimpleEventStore.Tests</Title>

--- a/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <Title>SimpleEventStore.Tests</Title>
     <Company>ASOS</Company>
-    <Copyright>Copyright ASOS © 2020</Copyright>
+    <Copyright>Copyright ASOS © 2024</Copyright>
     <Product>SimpleEventStore.Tests</Product>
   </PropertyGroup>
 </Project>

--- a/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
+++ b/src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/src/SimpleEventStore/SimpleEventStore/SimpleEventStore.csproj
+++ b/src/SimpleEventStore/SimpleEventStore/SimpleEventStore.csproj
@@ -8,7 +8,7 @@
     <Title>ASOS.SimpleEventStore</Title>
     <Description>Simple Event Store (SES) provides a lightweight event sourcing abstraction.</Description>
     <Company>ASOS</Company>
-    <Copyright>Copyright ASOS © 2023</Copyright>
+    <Copyright>Copyright ASOS © 2024</Copyright>
     <Product>SimpleEventStore</Product>
     <PackageId>Asos.SimpleEventStore</PackageId>
     <Authors>ASOS</Authors>


### PR DESCRIPTION
This pull request includes changes to the `SimpleEventStore` project, primarily focusing on code simplification, test assertion improvements, and package updates. The most important changes are the removal of unused variables, the transition from `Assert.AreEqual` to `Assert.That` for better readability, and the update of various packages to their newer versions.

Code simplification:

* [`src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreInitializing.cs`](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL50-R53): Removed unused `storageEngine` variables in multiple methods. [[1]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL50-R53) [[2]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL85-R94) [[3]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daR107-R110) [[4]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL123-R125)

Test assertion improvements:

* `src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreInitializing.cs` and `src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/AzureCosmosDbEventStoreLogging.cs`: Replaced `Assert.AreEqual` and `Assert.NotNull` with `Assert.That` for better readability and consistency. [[1]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL50-R53) [[2]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL85-R94) [[3]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daR107-R110) [[4]](diffhunk://#diff-8e610d18cc58dbc773e7caea9f8e8cc39864a7a29db7a212e08e24bb665c14daL123-R125) [[5]](diffhunk://#diff-1f6d081421b27378039da95cf8a26bd4d1e0efd39c435e52c83c384ceb486746L20-R20)

Package updates:

* `src/SimpleEventStore/SimpleEventStore.CosmosDb.Tests/SimpleEventStore.CosmosDb.Tests.csproj`, `src/SimpleEventStore/SimpleEventStore.CosmosDb/SimpleEventStore.CosmosDb.csproj`, and `src/SimpleEventStore/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj`: Updated the `TargetFramework` to `net8.0` and upgraded various packages to their newer versions, including `Microsoft.Extensions.Configuration`, `Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`, and `Microsoft.Azure.Cosmos`. [[1]](diffhunk://#diff-55b95d174bb40551d213c11325abec10158f8ea3f3837486a6b6d8077de59b45L4-R4) [[2]](diffhunk://#diff-55b95d174bb40551d213c11325abec10158f8ea3f3837486a6b6d8077de59b45L13-R18) [[3]](diffhunk://#diff-375d7ff6d155ebdee84cf34e8afcf3bf0e797ef8cf0aa41263ab6dc4972ab7d1L9-R9) [[4]](diffhunk://#diff-7facb793b9219eed76eb4c3a26d0f31a50fd1e125b9ee5661310c8b0aa21bbb2L4-R12)